### PR TITLE
sketch out basic handler skeleton with suggested stucture

### DIFF
--- a/handler/error.go
+++ b/handler/error.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+// Error is the handler package's error type. Is not meant to be compared as a
+// a type, but information should be extracted via the interfaces
+// it implements with callback functions. Is not guaranteed to remain exported
+// so shouldn't be treated as such.
+type Error struct {
+	err     error
+	logData map[string]interface{}
+}
+
+// Error implements the Go standard error interface
+func (e *Error) Error() string {
+	if e.err == nil {
+		return "nil"
+	}
+	return e.err.Error()
+}
+
+// LogData implements the DataLogger interface which allows you extract
+// embedded log.Data from an error
+func (e *Error) LogData() map[string]interface{} {
+	if e.logData == nil {
+		return log.Data{}
+	}
+	return e.logData
+}
+
+func (e *Error) Unwrap() error {
+	return e.err
+}

--- a/placeholder/cantabular.go
+++ b/placeholder/cantabular.go
@@ -1,0 +1,66 @@
+// Package placeholder is a temporary package for usage during development
+// of the main handler. The idea is to implement placeholder data structures
+// which are use for the inputs and outputs of the various steps of the export
+// process. This is to help aid development of the various steps in parallel,
+// so we can have a rough idea of what he have to use for each step. As each
+// step is completed we should replace the placeholder structure with the real
+// input/output and the placeholder structure should be deleted. The first
+// example is that placeholder.GraphQLQueryResponse will be replaced by the
+// real cantabular.GraphQLQueryResponse from the dp-api-clients-go/cantabular
+// package once it has been implemented. It can also be used for functions
+// which are yet to be implemented in external services, the prime example
+// being cantabular.GraphQLQuery()
+package placeholder
+
+import (
+	"context"
+)
+
+type QueryDatasetRequest struct {
+	Dataset   string
+	Variables []string
+}
+
+type QueryDatasetResponse struct {
+	Data struct {
+		Dataset Dataset
+	}
+	Errors []ErrorResponse
+}
+
+type Dataset struct {
+	Table Table
+}
+
+type Table struct {
+	Dimensions []Dimension
+	Values     []int
+	Error      string
+}
+
+type Variable struct {
+	Name, Label string
+}
+
+type Category struct {
+	Code, Label string
+}
+
+type Row struct {
+	Categories []Category
+	Count      int
+}
+
+type Dimension struct {
+	Count      int
+	Categories []Category
+	Variable   Variable
+}
+
+type ErrorResponse struct {
+	Message string
+}
+
+func QueryDataset(ctx context.Context, req QueryDatasetRequest) (*QueryDatasetResponse, error) {
+	return &QueryDatasetResponse{}, nil
+}


### PR DESCRIPTION
### What

Sketched out the rough outline for the handler skeleton based on the refinement session.

Each function/collection of 2-3 function maps to a particular ticket, and should be able to be worked
on independently.

Created a 'placeholder' package that will be replaced by data structures and functions from the Cantabular
client once implemented. The response should be accurate to what will be returned and allows for work
on the following functions to start without needing the full implementation.

Left comments/notes on each step of the process.

This is by no means a final verdict but a rough start, yet should be fairly accurate.

### How to review

Check code changes make sense, cross reference the epic here: `https://trello.com/c/AFmxxaS7/254-publish-fixed-dataset-from-cantabular` and make sure all steps are covered.

### Who can review

Anyone, may be more relevant to people from Team B as they will be picking up the work set out by it.
