### PR TITLE
parse cantabular response into csv format

### DIFF
--- a/cmd/producer/main.go
+++ b/cmd/producer/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ONSdigital/dp-cantabular-csv-exporter/event"
 	"github.com/ONSdigital/dp-cantabular-csv-exporter/schema"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const serviceName = "dp-cantabular-csv-exporter"
@@ -23,7 +23,7 @@ func main() {
 	// Get Config
 	cfg, err := config.Get()
 	if err != nil {
-		log.Event(ctx, "error getting config", log.FATAL, log.Error(err))
+		log.Fatal(ctx, "error getting config", err)
 		os.Exit(1)
 	}
 
@@ -33,7 +33,7 @@ func main() {
 		KafkaVersion: &cfg.KafkaVersion,
 	})
 	if err != nil {
-		log.Event(ctx, "fatal error trying to create kafka producer", log.FATAL, log.Error(err), log.Data{"topic": cfg.InstanceCompleteTopic})
+		log.Fatal(ctx, "fatal error trying to create kafka producer", err, log.Data{"topic": cfg.InstanceCompleteTopic})
 		os.Exit(1)
 	}
 
@@ -44,11 +44,11 @@ func main() {
 	scanner := bufio.NewScanner(os.Stdin)
 	for {
 		e := scanEvent(scanner)
-		log.Event(ctx, "sending hello-called event", log.INFO, log.Data{"helloCalledEvent": e})
+		log.Info(ctx, "sending hello-called event", log.Data{"helloCalledEvent": e})
 
 		bytes, err := schema.InstanceComplete.Marshal(e)
 		if err != nil {
-			log.Event(ctx, "hello-called event error", log.FATAL, log.Error(err))
+			log.Fatal(ctx, "hello-called event error", err)
 			os.Exit(1)
 		}
 

--- a/event/consumer.go
+++ b/event/consumer.go
@@ -17,17 +17,17 @@ func (p *Processor) Consume(ctx context.Context, cg kafka.IConsumerGroup, h Hand
 			select {
 			case msg, ok := <-cg.Channels().Upstream:
 				if !ok {
-					log.Event(ctx, "closing event consumer loop because upstream channel is closed", log.INFO, log.Data{"worker_id": workerID})
+					log.Info(ctx, "closing event consumer loop because upstream channel is closed", log.Data{"worker_id": workerID})
 					return
 				}
 
 				msgCtx, cancel := context.WithCancel(ctx)
 
 				if err := p.processMessage(msgCtx, msg, h); err != nil {
-					log.Event(
+					log.Error(
 						msgCtx,
 						"failed to process message",
-						log.ERROR,
+						err,
 						log.Data{
 							"error":       fmt.Sprintf("%s", err),
 							"log_data":    unwrapLogData(err),
@@ -38,7 +38,7 @@ func (p *Processor) Consume(ctx context.Context, cg kafka.IConsumerGroup, h Hand
 				msg.Release()
 				cancel()
 			case <-cg.Channels().Closer:
-				log.Event(ctx, "closing event consumer loop because closer channel is closed", log.INFO, log.Data{"worker_id": workerID})
+				log.Info(ctx, "closing event consumer loop because closer channel is closed", log.Data{"worker_id": workerID})
 				return
 			case <-ctx.Done():
 				log.Info(ctx, "parent context closed - closing event consumer loop ", log.Data{"worker_id": workerID})

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/dp-s3 v1.7.0
 	github.com/ONSdigital/dp-vault v1.2.0
-	github.com/ONSdigital/log.go v1.0.1
 	github.com/ONSdigital/log.go/v2 v2.0.5
 	github.com/aws/aws-sdk-go v1.40.13
 	github.com/cucumber/godog v0.11.0

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -86,14 +86,27 @@ func TestValidateQueryResponse(t *testing.T) {
 			c := cantabularResp()
 			c.Dataset.Table.Dimensions[0].Count = 250
 			err := eventHandler.ValidateQueryResponse(c)
-			So(err, ShouldResemble, errors.New("wrong number of categories for a dimensions in response"))
+			So(err, ShouldResemble, handler.NewError(
+				errors.New("wrong number of categories for a dimensions in response"),
+				log.Data{
+					"categories_length": 3,
+					"dimension_count":   250,
+					"dimension":         "City",
+				},
+			))
 		})
 
 		Convey("Validating a cantabular response with a values array whose length does not match the permutations of all dimension categories fails with the expected error", func() {
 			c := cantabularResp()
 			c.Dataset.Table.Values = []int{0, 1, 2, 3}
 			err := eventHandler.ValidateQueryResponse(c)
-			So(err, ShouldResemble, errors.New("wrong number of values in response"))
+			So(err, ShouldResemble, handler.NewError(
+				errors.New("wrong number of values in response"),
+				log.Data{
+					"expected_values": 18,
+					"values_length":   4,
+				},
+			))
 		})
 	})
 }

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ONSdigital/dp-cantabular-csv-exporter/config"
 	"github.com/ONSdigital/dp-cantabular-csv-exporter/service"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const serviceName = "dp-cantabular-csv-exporter"
@@ -27,7 +27,7 @@ func main() {
 	ctx := context.Background()
 
 	if err := run(ctx); err != nil {
-		log.Event(ctx, "fatal runtime error", log.Error(err), log.FATAL)
+		log.Fatal(ctx, "fatal runtime error", err)
 		os.Exit(1)
 	}
 }
@@ -53,9 +53,9 @@ func run(ctx context.Context) error {
 	// blocks until an os interrupt or a fatal error occurs
 	select {
 	case err := <-svcErrors:
-		log.Event(ctx, "service error received", log.ERROR, log.Error(err))
+		log.Error(ctx, "service error received", err)
 	case sig := <-signals:
-		log.Event(ctx, "os signal received", log.Data{"signal": sig}, log.INFO)
+		log.Info(ctx, "os signal received", log.Data{"signal": sig})
 	}
 	return svc.Close(ctx)
 }


### PR DESCRIPTION
### What

trello: https://trello.com/c/6YxTnarX/5178-dp-cantabular-csv-exporter-process-json-response-from-cantabular
- Parse Cantabular query response to the expected CSV format
- Replaced the ReadWriter with an internal writer used by the func responsible to parse the response and a Reader returned and provided to S3 (with the same underlying byte buffer) 
- Improved Cantabular response validation

example of generated file (tested end-to-end with a testing bucket in develop):
```
City,Number of siblings (3 mappings),Sex,count
London,No siblings,Male,1
London,No siblings,Female,0
London,1 or 2 siblings,Male,0
London,1 or 2 siblings,Female,0
London,3 or more siblings,Male,0
London,3 or more siblings,Female,1
Liverpool,No siblings,Male,0
Liverpool,No siblings,Female,0
Liverpool,1 or 2 siblings,Male,0
Liverpool,1 or 2 siblings,Female,0
Liverpool,3 or more siblings,Male,1
Liverpool,3 or more siblings,Female,0
Belfast,No siblings,Male,0
Belfast,No siblings,Female,0
Belfast,1 or 2 siblings,Male,1
Belfast,1 or 2 siblings,Female,0
Belfast,3 or more siblings,Male,0
Belfast,3 or more siblings,Female,2
```
- Document that defines the expected format: https://docs.google.com/document/d/1GHgfpgRVRCdh3P3UvJJ0LqN3cgpyTe_Ew6zGMm-k02I/edit#heading=h.17xna6djmuzc

### How to review

- Make sure changes make sense
- Make sure unit tests pass
- Make sure provided output matches the expected format by the document
- (info) Tested with a local dp-compose setup, but using a real S3 connection, and a testing bucket. The generated file is still in the bucket;
  - bucket name: `ons-dp-develop-cantabular-csv-exported`
  - file: `eef35f63-791f-4561-9f0a-a4398a4e021f-1ed9a683-36e3-47bf-bf28-ee108950a91f.csv`
You may copy the file locally and inspect it by using the following aws cli command: `aws s3 cp s3://ons-dp-develop-cantabular-csv-exported/eef35f63-791f-4561-9f0a-a4398a4e021f-1ed9a683-36e3-47bf-bf28-ee108950a91f.csv .`

### Who can review

anyone