### PR TITLE
replaced Cantabular healthcheck with a placeholder

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/ONSdigital/dp-cantabular-csv-exporter/config"
 	"github.com/ONSdigital/dp-cantabular-csv-exporter/handler"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
@@ -170,7 +172,13 @@ func (svc *Service) registerCheckers() error {
 		return fmt.Errorf("error adding check for Kafka: %w", err)
 	}
 
-	if err := svc.healthCheck.AddCheck("Cantabular client", svc.cantabularClient.Checker); err != nil {
+	// TODO - when Cantabular server is deployed to Production, remove this placeholder
+	// and use the real Checker instead: svc.cantabularClient.Checker
+	placeholderChecker := func(ctx context.Context, state *healthcheck.CheckState) error {
+		state.Update(healthcheck.StatusOK, "Cantabular healthcheck placeholder", http.StatusOK)
+		return nil
+	}
+	if err := svc.healthCheck.AddCheck("Cantabular client", placeholderChecker); err != nil {
 		return fmt.Errorf("error adding check for cantabular client: %w", err)
 	}
 


### PR DESCRIPTION
### What

- Replaced Cantabular healthcheck Checker with a placeholder.
This needs to be done in order to release this service to production, where the Cantabular server is not running yet. Once it is running, we can undo this change and use the real Checker again.

### How to review

- Make sure code change makes sense
- Make sure unit tests pass
- (info) tested the`/health` endpoint locally and validated that a successful check with the placeholder text appears.

### Who can review

anyone