### PR TITLE
Remove log of response from query as it can be over 4 Megabytes

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -89,10 +89,6 @@ func (h *InstanceComplete) Handle(ctx context.Context, e *event.InstanceComplete
 		}
 	}
 
-	log.Info(ctx, "response from Cantabular Extended API GraphQL query", log.Data{
-		"resp": resp,
-	})
-
 	if err := h.ValidateQueryResponse(resp); err != nil {
 		return &Error{
 			err:     fmt.Errorf("failed to validate query response: %w", err),


### PR DESCRIPTION

### What

This log line has been removed as we saw a log line of 4 Meg for a census database that was 1% of the final - so some logs could end up being in the Gigabytes - which will cause Out Of Memory issues.

### How to review

Visual inspect

### Who can review

Anyone