### PR TITLE
Fix/download link

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	CantabularURL                string        `envconfig:"CANTABULAR_URL"`
 	CantabularExtURL             string        `envconfig:"CANTABULAR_EXT_API_URL"`
 	DatasetAPIURL                string        `envconfig:"DATASET_API_URL"`
+	DownloadServiceURL           string        `envconfig:"DOWNLOAD_SERVICE_URL"`
 	CantabularHealthcheckEnabled bool          `envconfig:"CANTABULAR_HEALTHCHECK_ENABLED"`
 	AWSRegion                    string        `envconfig:"AWS_REGION"`
 	UploadBucketName             string        `envconfig:"UPLOAD_BUCKET_NAME"`
@@ -34,7 +35,7 @@ type Config struct {
 	VaultToken                   string        `envconfig:"VAULT_TOKEN"                   json:"-"`
 	VaultAddress                 string        `envconfig:"VAULT_ADDR"`
 	VaultPath                    string        `envconfig:"VAULT_PATH"`
-	Encrypt                      bool          `envconfig:"ENCRYPT"`
+	EncryptionDisabled           bool          `envconfig:"ENCRYPTION_DISABLED"`
 }
 
 var cfg *Config
@@ -64,16 +65,17 @@ func Get() (*Config, error) {
 		CantabularURL:                "http://localhost:8491",
 		CantabularExtURL:             "http://localhost:8492",
 		DatasetAPIURL:                "http://localhost:22000",
+		DownloadServiceURL:           "http://localhost:23600",
 		CantabularHealthcheckEnabled: false,
 		AWSRegion:                    "eu-west-1",
-		UploadBucketName:             "dp-cantabular-csv-exporter",
+		UploadBucketName:             "ons-dp-develop-encrypted-datasets",
 		LocalObjectStore:             "",
 		MinioAccessKey:               "",
 		MinioSecretKey:               "",
 		VaultPath:                    "secret/shared/psk",
 		VaultAddress:                 "http://localhost:8200",
 		VaultToken:                   "",
-		Encrypt:                      false,
+		EncryptionDisabled:           false,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -68,7 +68,7 @@ func Get() (*Config, error) {
 		DownloadServiceURL:           "http://localhost:23600",
 		CantabularHealthcheckEnabled: false,
 		AWSRegion:                    "eu-west-1",
-		UploadBucketName:             "ons-dp-develop-encrypted-datasets",
+		UploadBucketName:             "dp-cantabular-csv-exporter",
 		LocalObjectStore:             "",
 		MinioAccessKey:               "",
 		MinioSecretKey:               "",

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	VaultToken                   string        `envconfig:"VAULT_TOKEN"                   json:"-"`
 	VaultAddress                 string        `envconfig:"VAULT_ADDR"`
 	VaultPath                    string        `envconfig:"VAULT_PATH"`
+	Encrypt                      bool          `envconfig:"ENCRYPT"`
 }
 
 var cfg *Config
@@ -72,6 +73,7 @@ func Get() (*Config, error) {
 		VaultPath:                    "secret/shared/psk",
 		VaultAddress:                 "http://localhost:8200",
 		VaultToken:                   "",
+		Encrypt:                      false,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,10 +40,11 @@ func TestConfig(t *testing.T) {
 				So(cfg.CantabularURL, ShouldEqual, "http://localhost:8491")
 				So(cfg.CantabularExtURL, ShouldEqual, "http://localhost:8492")
 				So(cfg.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
+				So(cfg.DownloadServiceURL, ShouldEqual, "http://localhost:23600")
 				So(cfg.CantabularHealthcheckEnabled, ShouldBeFalse)
 				So(cfg.AWSRegion, ShouldEqual, "eu-west-1")
 				So(cfg.UploadBucketName, ShouldEqual, "dp-cantabular-csv-exporter")
-				So(cfg.Encrypt, ShouldBeFalse)
+				So(cfg.EncryptionDisabled, ShouldBeFalse)
 			})
 
 			Convey("Then a second call to config should return the same config", func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,6 +43,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.CantabularHealthcheckEnabled, ShouldBeFalse)
 				So(cfg.AWSRegion, ShouldEqual, "eu-west-1")
 				So(cfg.UploadBucketName, ShouldEqual, "dp-cantabular-csv-exporter")
+				So(cfg.Encrypt, ShouldBeFalse)
 			})
 
 			Convey("Then a second call to config should return the same config", func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,7 +43,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.DownloadServiceURL, ShouldEqual, "http://localhost:23600")
 				So(cfg.CantabularHealthcheckEnabled, ShouldBeFalse)
 				So(cfg.AWSRegion, ShouldEqual, "eu-west-1")
-				So(cfg.UploadBucketName, ShouldEqual, "ons-dp-develop-encrypted-datasets")
+				So(cfg.UploadBucketName, ShouldEqual, "dp-cantabular-csv-exporter")
 				So(cfg.EncryptionDisabled, ShouldBeFalse)
 			})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,7 +43,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.DownloadServiceURL, ShouldEqual, "http://localhost:23600")
 				So(cfg.CantabularHealthcheckEnabled, ShouldBeFalse)
 				So(cfg.AWSRegion, ShouldEqual, "eu-west-1")
-				So(cfg.UploadBucketName, ShouldEqual, "dp-cantabular-csv-exporter")
+				So(cfg.UploadBucketName, ShouldEqual, "ons-dp-develop-encrypted-datasets")
 				So(cfg.EncryptionDisabled, ShouldBeFalse)
 			})
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"path"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
@@ -394,5 +393,5 @@ func generateS3Filename(instanceID string) string {
 
 // generateVaultPathForFile generates the vault path for the provided root and filename
 func generateVaultPathForFile(vaultPathRoot, filename string) string {
-	return fmt.Sprintf("%s/%s", vaultPathRoot, path.Base(filename))
+	return fmt.Sprintf("%s/%s", vaultPathRoot, filename)
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -26,9 +26,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// Encrypted determines if files need to be encrypted with a newly generated key when they are stored in S3
-const Encrypted = false
-
 // InstanceComplete is the handle for the InstanceCompleteHandler event
 type InstanceComplete struct {
 	cfg         config.Config
@@ -107,7 +104,7 @@ func (h *InstanceComplete) Handle(ctx context.Context, e *event.InstanceComplete
 	// creating a CSV file, not just parsing the response into a generic struct.
 
 	// Upload CSV file to S3
-	uploadedUrl, err := h.UploadCSVFile(ctx, e.InstanceID, file, Encrypted)
+	uploadedUrl, err := h.UploadCSVFile(ctx, e.InstanceID, file, h.cfg.Encrypt)
 	if err != nil {
 		return &Error{
 			err: fmt.Errorf("failed to upload .csv file to S3 bucket: %w", err),

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -123,11 +123,11 @@ func TestParseQueryResponse(t *testing.T) {
 		eventHandler := handler.NewInstanceComplete(testCfg(), nil, nil, nil, nil, nil)
 
 		Convey("When ParseQueryResponse is triggered with a valid cantabular response", func() {
-			reader, len, err := eventHandler.ParseQueryResponse(cantabularResp())
+			reader, numBytes, err := eventHandler.ParseQueryResponse(cantabularResp())
 
 			Convey("Then the expected reader is returned without error", func() {
 				So(err, ShouldBeNil)
-				So(len, ShouldEqual, 631)
+				So(numBytes, ShouldEqual, 631)
 				validateLines(reader, []string{
 					"City,Number of siblings (3 mappings),Sex,count",
 					"London,No siblings,Male,2",

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -123,10 +123,11 @@ func TestParseQueryResponse(t *testing.T) {
 		eventHandler := handler.NewInstanceComplete(testCfg(), nil, nil, nil, nil, nil)
 
 		Convey("When ParseQueryResponse is triggered with a valid cantabular response", func() {
-			reader, err := eventHandler.ParseQueryResponse(cantabularResp())
+			reader, len, err := eventHandler.ParseQueryResponse(cantabularResp())
 
 			Convey("Then the expected reader is returned without error", func() {
 				So(err, ShouldBeNil)
+				So(len, ShouldEqual, 631)
 				validateLines(reader, []string{
 					"City,Number of siblings (3 mappings),Sex,count",
 					"London,No siblings,Male,2",

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -169,7 +169,7 @@ func validateLines(reader *bufio.Reader, expectedLines []string) {
 func TestUploadCSVFile(t *testing.T) {
 
 	expectedS3Key := fmt.Sprintf("instances/%s.csv", testInstanceID)
-	expectedVaultPath := fmt.Sprintf("%s/%s.csv", testVaultPath, testInstanceID)
+	expectedVaultPath := fmt.Sprintf("%s/instances/%s.csv", testVaultPath, testInstanceID)
 
 	Convey("Given an event handler with a successful S3Uploader", t, func() {
 		s3Uploader := s3UploaderHappy(false)

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -93,7 +93,10 @@ var GetS3Uploader = func(cfg *config.Config) (S3Uploader, error) {
 			S3ForcePathStyle: aws.Bool(true),
 		}
 
-		s := session.New(s3Config)
+		s, err := session.NewSession(s3Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create aws session: %w", err)
+		}
 		return dps3.NewUploaderWithSession(cfg.UploadBucketName, s), nil
 	}
 


### PR DESCRIPTION
### What

- Created download service link, instead of using the S3 url directly
- Created feature flag to enable or disable encryption, with the same name as the download service feature flag (so that it's easy to make it consistent in an environment)
- Added vault client and healthcheck only when encryption is enabled
- Improved unit tests

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (note): tested locally using the latest [dp-compose](https://github.com/ONSdigital/dp-compose/pull/33), along with the changes in [dp-download-service](https://github.com/ONSdigital/dp-download-service/pull/71)

### Who can review

anyone