### PR TITLE
for isPublished==true, update 'public' link instead of 'href', and set instance to 'published' state

### DIFF
--- a/features/dp-cantabular-csv-exporter.feature
+++ b/features/dp-cantabular-csv-exporter.feature
@@ -145,5 +145,5 @@ Feature: Cantabular-Csv-Exporter
     And a file with filename "instances/instance-happy-01.csv" can be seen in minio
 
     Then these common-output-created events are produced:
-      | InstanceID        | FileURL                                                          |
-      | instance-happy-01 | http://localhost:23600/downloads/instances/instance-happy-01.csv |
+      | InstanceID        | FileURL                                                                      |
+      | instance-happy-01 | http://minio:9000/dp-cantabular-csv-exporter/instances/instance-happy-01.csv |


### PR DESCRIPTION
### What

We need to provide the S3URL as public link, as well as updating the instance state to 'published' so that the download service redirects to the static bucket URL.
This is needed to make sure we have a public link available for: https://trello.com/c/R5Qt3KtP/5260-use-static-bucket-for-published-cantabular-csv-files

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone. Suggested @andre-urbani 