### PR TITLE
when using a public link, we need to set the instance to associated s…

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -440,10 +440,10 @@ func TestUpdateInstance(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
-			Convey("Then the expected UpdateInstance call is executed with the expected paramters", func() {
+			Convey("Then the expected UpdateInstance call is executed once to update the public download link and associate it, and once more to publish it", func() {
 				expectedURL := "publicURL"
 				So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 0)
-				So(datasetAPIMock.PutInstanceCalls(), ShouldHaveLength, 1)
+				So(datasetAPIMock.PutInstanceCalls(), ShouldHaveLength, 2)
 				So(datasetAPIMock.PutInstanceCalls()[0].InstanceID, ShouldEqual, testInstanceID)
 				So(datasetAPIMock.PutInstanceCalls()[0].InstanceUpdate, ShouldResemble, dataset.UpdateInstance{
 					Downloads: dataset.DownloadList{
@@ -452,6 +452,10 @@ func TestUpdateInstance(t *testing.T) {
 							Size:   fmt.Sprintf("%d", testSize),
 						},
 					},
+					State: dataset.StateAssociated.String(),
+				})
+				So(datasetAPIMock.PutInstanceCalls()[1].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIMock.PutInstanceCalls()[1].InstanceUpdate, ShouldResemble, dataset.UpdateInstance{
 					State: dataset.StatePublished.String(),
 				})
 				So(datasetAPIMock.PutInstanceCalls()[0].IfMatch, ShouldEqual, headers.IfMatchAnyETag)


### PR DESCRIPTION
### What

Associate the instance before publishing it (needed by the public link to be available from the download service, as the instance can't go from edition-confirmed to published directly)

https://trello.com/c/5u9Gq7VT/5273-research-cmd-implementation-and-identify-endpoints-to-be-used

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone