### PR TITLE
Don't update instance state on UpdateInstance - only file URL

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -371,38 +371,26 @@ func (h *InstanceComplete) UpdateInstance(ctx context.Context, instanceID string
 		update := dataset.UpdateInstance{
 			Downloads: dataset.DownloadList{
 				CSV: &dataset.Download{
+					URL:    s3Url,                   // Public URL, as returned by the S3 uploader
 					Public: s3Url,                   // Public URL, as returned by the S3 uploader
 					Size:   fmt.Sprintf("%d", size), // size of the file in number of bytes
 				},
 			},
-			State: dataset.StateAssociated.String(), // set state to associated (required before it can be set to published)
-		}
-
-		// update download links and associate instance
-		if _, err := h.datasets.PutInstance(ctx, "", h.cfg.ServiceAuthToken, "", instanceID, update, headers.IfMatchAnyETag); err != nil {
-			return fmt.Errorf("error during put instance: %w", err)
-		}
-
-		// publish instance
-		update = dataset.UpdateInstance{
-			State: dataset.StatePublished.String(),
 		}
 		if _, err := h.datasets.PutInstance(ctx, "", h.cfg.ServiceAuthToken, "", instanceID, update, headers.IfMatchAnyETag); err != nil {
 			return fmt.Errorf("error during put instance: %w", err)
 		}
-
 		return nil
 	}
 
 	update := dataset.UpdateInstance{
 		Downloads: dataset.DownloadList{
 			CSV: &dataset.Download{
-				Size: fmt.Sprintf("%d", size), // size of the file in number of bytes
+				Size: fmt.Sprintf("%d", size),                                  // size of the file in number of bytes
+				URL:  generatePrivateURL(h.cfg.DownloadServiceURL, instanceID), // Private downloadService URL
 			},
 		},
 	}
-	update.Downloads.CSV.URL = generatePrivateURL(h.cfg.DownloadServiceURL, instanceID)
-
 	if _, err := h.datasets.PutInstance(ctx, "", h.cfg.ServiceAuthToken, "", instanceID, update, headers.IfMatchAnyETag); err != nil {
 		return fmt.Errorf("error during put instance: %w", err)
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -443,22 +443,17 @@ func TestUpdateInstance(t *testing.T) {
 			Convey("Then the expected UpdateInstance call is executed once to update the public download link and associate it, and once more to publish it", func() {
 				expectedURL := "publicURL"
 				So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 0)
-				So(datasetAPIMock.PutInstanceCalls(), ShouldHaveLength, 2)
+				So(datasetAPIMock.PutInstanceCalls(), ShouldHaveLength, 1)
 				So(datasetAPIMock.PutInstanceCalls()[0].InstanceID, ShouldEqual, testInstanceID)
 				So(datasetAPIMock.PutInstanceCalls()[0].InstanceUpdate, ShouldResemble, dataset.UpdateInstance{
 					Downloads: dataset.DownloadList{
 						CSV: &dataset.Download{
 							Public: expectedURL,
+							URL:    expectedURL,
 							Size:   fmt.Sprintf("%d", testSize),
 						},
 					},
-					State: dataset.StateAssociated.String(),
 				})
-				So(datasetAPIMock.PutInstanceCalls()[1].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIMock.PutInstanceCalls()[1].InstanceUpdate, ShouldResemble, dataset.UpdateInstance{
-					State: dataset.StatePublished.String(),
-				})
-				So(datasetAPIMock.PutInstanceCalls()[0].IfMatch, ShouldEqual, headers.IfMatchAnyETag)
 			})
 		})
 	})


### PR DESCRIPTION
### What

- Don't update the instance state on `UpdateInstance` (only the download link)
- We will always return the S3 URL directly (instead of download service)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone