### PR TITLE
Bugfix: generator should be initialised before the handler to prevent nil pointer

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -61,6 +61,7 @@ func (svc *Service) Init(ctx context.Context, cfg *config.Config, buildTime, git
 
 	svc.CantabularClient = GetCantabularClient(cfg)
 	svc.DatasetAPIClient = GetDatasetAPIClient(cfg)
+	svc.generator = GetGenerator()
 
 	h := handler.NewInstanceComplete(
 		*svc.Cfg,
@@ -73,7 +74,6 @@ func (svc *Service) Init(ctx context.Context, cfg *config.Config, buildTime, git
 		svc.generator,
 	)
 	svc.Consumer.RegisterHandler(ctx, h.Handle)
-	svc.generator = GetGenerator()
 
 	// Get HealthCheck
 	if svc.HealthCheck, err = GetHealthCheck(cfg, buildTime, gitCommit, version); err != nil {


### PR DESCRIPTION
### What

Bugfix: Currently, `dp-cantabular-csv-exporter` is in an infinite restart loop in develop.
This is due to a nil pointer caused by a field being assigned too late in service (it's required by the handler and it is nil).

This PR fixes this.

### How to review

inspect code - this was also fixed in another PR, which is not ready yet to be merged to develop.

### Who can review

anyone