### PR TITLE
added  to instance validation, which was causing a panick

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -81,8 +81,6 @@ func (h *InstanceComplete) Handle(ctx context.Context, workerID int, msg kafka.M
 		return fmt.Errorf("failed to validate instance: %w", err)
 	}
 
-	log.Info(ctx, "+++ DEBUG +++ Instance validated", log.Data{"is_published": isPublished})
-
 	req := cantabular.StaticDatasetQueryRequest{
 		Dataset:   instance.IsBasedOn.ID, // This value corresponds to the CantabularBlob that was used in import process
 		Variables: instance.CSVHeader[1:],
@@ -131,6 +129,16 @@ func (h *InstanceComplete) ValidateInstance(i dataset.Instance) (bool, error) {
 			},
 		}
 	}
+
+	if i.IsBasedOn == nil || len(i.IsBasedOn.ID) == 0 {
+		return false, &Error{
+			err: errors.New("missing instance isBasedOn.ID"),
+			logData: log.Data{
+				"is_based_on": i.IsBasedOn,
+			},
+		}
+	}
+
 	return i.State == dataset.StatePublished.String(), nil
 }
 
@@ -158,8 +166,6 @@ func (h *InstanceComplete) UploadCSVFile(ctx context.Context, e *event.ExportSta
 
 		// stream consumer/uploader for public files
 		consume = func(ctx context.Context, file io.Reader) error {
-			log.Info(ctx, "+++ DEBUG +++ Starting published consume...", logData)
-
 			if file == nil {
 				return errors.New("no file content has been provided")
 			}
@@ -217,8 +223,6 @@ func (h *InstanceComplete) UploadCSVFile(ctx context.Context, e *event.ExportSta
 				return nil
 			}
 		} else {
-			log.Info(ctx, "+++ DEBUG +++ Generating new PSK", logData)
-
 			psk, err := h.generator.NewPSK()
 			if err != nil {
 				return "", 0, NewError(
@@ -226,8 +230,6 @@ func (h *InstanceComplete) UploadCSVFile(ctx context.Context, e *event.ExportSta
 					logData,
 				)
 			}
-
-			log.Info(ctx, "+++ DEBUG +++ Generating vault path for file", logData)
 
 			vaultPath := generateVaultPathForFile(h.cfg.VaultPath, e)
 			vaultKey := "key"

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -77,6 +77,7 @@ func TestValidateInstance(t *testing.T) {
 		i := dataset.Instance{
 			Version: dataset.Version{
 				CSVHeader: []string{"1", "2"},
+				IsBasedOn: &dataset.IsBasedOn{ID: "myID"},
 				State:     dataset.StatePublished.String(),
 			},
 		}
@@ -91,6 +92,7 @@ func TestValidateInstance(t *testing.T) {
 		i := dataset.Instance{
 			Version: dataset.Version{
 				CSVHeader: []string{"1", "2"},
+				IsBasedOn: &dataset.IsBasedOn{ID: "myID"},
 				State:     dataset.StateAssociated.String(),
 			},
 		}
@@ -105,6 +107,7 @@ func TestValidateInstance(t *testing.T) {
 		i := dataset.Instance{
 			Version: dataset.Version{
 				CSVHeader: []string{"1", "2"},
+				IsBasedOn: &dataset.IsBasedOn{ID: "myID"},
 			},
 		}
 		Convey("Then ValidateInstance determines that instance is not published, without error", func() {
@@ -118,6 +121,7 @@ func TestValidateInstance(t *testing.T) {
 		i := dataset.Instance{
 			Version: dataset.Version{
 				CSVHeader: []string{"1"},
+				IsBasedOn: &dataset.IsBasedOn{ID: "myID"},
 			},
 		}
 		Convey("Then ValidateInstance returns the expected error", func() {
@@ -125,6 +129,39 @@ func TestValidateInstance(t *testing.T) {
 			So(err, ShouldResemble, handler.NewError(
 				errors.New("no dimensions in headers"),
 				log.Data{"headers": []string{"1"}},
+			))
+		})
+	})
+
+	Convey("Given an instance without isBasedOn field", t, func() {
+		i := dataset.Instance{
+			Version: dataset.Version{
+				CSVHeader: []string{"1", "2"},
+				State:     dataset.StatePublished.String(),
+			},
+		}
+		Convey("Then ValidateInstance returns the expected error", func() {
+			_, err := h.ValidateInstance(i)
+			So(err, ShouldResemble, handler.NewError(
+				errors.New("missing instance isBasedOn.ID"),
+				log.Data{"is_based_on": (*dataset.IsBasedOn)(nil)},
+			))
+		})
+	})
+
+	Convey("Given an instance with an empty isBasedOn field", t, func() {
+		i := dataset.Instance{
+			Version: dataset.Version{
+				CSVHeader: []string{"1", "2"},
+				State:     dataset.StatePublished.String(),
+				IsBasedOn: &dataset.IsBasedOn{},
+			},
+		}
+		Convey("Then ValidateInstance returns the expected error", func() {
+			_, err := h.ValidateInstance(i)
+			So(err, ShouldResemble, handler.NewError(
+				errors.New("missing instance isBasedOn.ID"),
+				log.Data{"is_based_on": &dataset.IsBasedOn{}},
 			))
 		})
 	})

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func run(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic: %s", r)
+			fmt.Printf("\n%s\n", err)
 		}
 	}()
 


### PR DESCRIPTION
### What

- bugfix: instance validation needs to check for the presence of `is_based_on` field to prevent any possible panic when trying to access the value.
- removed debug logs

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone
