### PR TITLE
Fix downloads no longer being generated generating for cantabular table type

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -2,11 +2,11 @@ package event
 
 // ExportStart provides an avro structure for a Export Start event
 type ExportStart struct {
-	InstanceID string `avro:"instance_id"`
-	DatasetID  string `avro:"dataset_id"`
-	Edition    string `avro:"edition"`
-	Version    string `avro:"version"`
-	FilterID   string `avro:"filter_id"`
+	InstanceID     string `avro:"instance_id"`
+	DatasetID      string `avro:"dataset_id"`
+	Edition        string `avro:"edition"`
+	Version        string `avro:"version"`
+	FilterOutputID string `avro:"filter_output_id"`
 }
 
 // CSVCreated provides an avro structure for a CSV Created event

--- a/features/dp-cantabular-csv-exporter-published-filtered.feature
+++ b/features/dp-cantabular-csv-exporter-published-filtered.feature
@@ -144,7 +144,7 @@ Feature: Cantabular-Csv-Exporter-Published-Filtered
       """
 
     And a dataset version with dataset-id "dataset-happy-02", edition "edition-happy-02" and version "version-happy-02" is updated by an API call to dp-dataset-api
-    And for the following filter "filter-happy-02" these dimensions are available:
+    And for the following filter "filter-output-happy-02" these dimensions are available:
     """
     {
       "items": [
@@ -176,10 +176,10 @@ Feature: Cantabular-Csv-Exporter-Published-Filtered
     }
     """
 
-    And the following job state is returned for the filter "filter-happy-02":
+    And the following filter is returned for the filter output "filter-output-happy-02":
     """
     {
-      "filter_id": "filter-happy-02",
+      "filter_id": "filter-output-happy-02",
       "links": {
         "version": {
           "href": "http://mockhost:9999/datasets/cantabular-example-1/editions/2021/version/1",
@@ -205,18 +205,18 @@ Feature: Cantabular-Csv-Exporter-Published-Filtered
 
 
 
-  Scenario: Consuming a cantabular-export-start event with correct fields for a published instance with a filter id present
+  Scenario: Consuming a cantabular-export-start event with correct fields for a published instance with a filter output id present
 
     When the service starts
 
     And this cantabular-export-start event is queued, to be consumed:
       """
       {
-        "InstanceID": "instance-happy-02",
-        "DatasetID":  "dataset-happy-02",
-        "Edition":    "edition-happy-02",
-        "Version":    "version-happy-02",
-        "FilterID":   "filter-happy-02"
+        "InstanceID":     "instance-happy-02",
+        "DatasetID":      "dataset-happy-02",
+        "Edition":        "edition-happy-02",
+        "Version":        "version-happy-02",
+        "FilterOutputID": "filter-output-happy-02"
       }
       """
 

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -33,7 +33,7 @@ func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the following instance with id "([^"]*)" is available from dp-dataset-api:$`, c.theFollowingInstanceIsAvailable)
 	ctx.Step(`^a dataset version with dataset-id "([^"]*)", edition "([^"]*)" and version "([^"]*)" is updated by an API call to dp-dataset-api`, c.theFollowingVersionIsUpdated)
 	ctx.Step(`^for the following filter "([^"]*)" these dimensions are available:$`, c.theFollowingFilterDimensionsExist)
-	ctx.Step(`^the following job state is returned for the filter "([^"]*)":$`, c.theFollowingJobStateIsReturned)
+	ctx.Step(`^the following filter is returned for the filter output "([^"]*)":$`, c.theFollowingJobStateIsReturned)
 	ctx.Step(`^this cantabular-export-start event is queued, to be consumed:$`, c.thisExportStartEventIsQueued)
 	ctx.Step(`^one event with the following fields are in the produced kafka topic cantabular-csv-created:$`, c.theseCsvCreatedEventsAreProduced)
 	ctx.Step(`^no cantabular-csv-created events are produced`, c.noCsvCreatedEventsAreProduced)
@@ -146,7 +146,7 @@ func (c *Component) theFollowingFilterDimensionsExist(filterID string, instance 
 // theFollowingJobStateIsReturned mocks filter api response for
 // GET /filters/{filter_id}
 func (c *Component) theFollowingJobStateIsReturned(filterID string, instance *godog.DocString) error {
-	uri := fmt.Sprintf("/filters/%s", filterID)
+	uri := fmt.Sprintf("/filter-outputs/%s", filterID)
 	c.FilterAPI.NewHandler().
 		Get(uri).
 		Reply(http.StatusOK).

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -118,7 +118,7 @@ func (h *InstanceComplete) Handle(ctx context.Context, workerID int, msg kafka.M
 }
 
 func (h *InstanceComplete) getFilterInfo(ctx context.Context, filterID string, logData log.Data) ([]string, string, bool, error) {
-	model, _, err := h.filters.GetJobState(ctx, "", h.cfg.ServiceAuthToken, "", "", filterID)
+	model, err := h.filters.GetOutput(ctx, "", h.cfg.ServiceAuthToken, "", "", filterID)
 	if err != nil {
 		return nil, "", false, &Error{
 			err:     errors.Wrap(err, "failed to get filter"),

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -71,8 +71,8 @@ func (h *InstanceComplete) Handle(ctx context.Context, workerID int, msg kafka.M
 
 	var err error
 
-	if e.FilterID != "" {
-		req.Variables, req.Dataset, isPublished, err = h.getFilterInfo(ctx, e.FilterID, logData)
+	if e.FilterOutputID != "" {
+		req.Variables, req.Dataset, isPublished, err = h.getFilterInfo(ctx, e.FilterOutputID, logData)
 		if err != nil {
 			return errors.Wrap(err, "failed to get filter info")
 		}
@@ -397,7 +397,7 @@ func (h *InstanceComplete) ProduceExportCompleteEvent(e *event.ExportStart, rowC
 
 // generateS3Filename generates the S3 key (filename including `subpaths` after the bucket) for the provided instanceID
 func generateS3Filename(e *event.ExportStart) string {
-	if e.FilterID != "" {
+	if e.FilterOutputID != "" {
 		return fmt.Sprintf("datasets/%s-%s-%s-filtered-%s.csv", e.DatasetID, e.Edition, e.Version, time.Now().Format(time.RFC3339))
 	}
 	return fmt.Sprintf("datasets/%s-%s-%s.csv", e.DatasetID, e.Edition, e.Version)
@@ -405,7 +405,7 @@ func generateS3Filename(e *event.ExportStart) string {
 
 // generateVaultPathForFile generates the vault path for the provided root and filename
 func generateVaultPathForFile(vaultPathRoot string, e *event.ExportStart) string {
-	if e.FilterID != "" {
+	if e.FilterOutputID != "" {
 		return fmt.Sprintf("%s/%s-%s-%s-filtered-%s.csv", vaultPathRoot, e.DatasetID, e.Edition, e.Version, time.Now().Format(time.RFC3339))
 	}
 	return fmt.Sprintf("%s/%s-%s-%s.csv", vaultPathRoot, e.DatasetID, e.Edition, e.Version)

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -37,7 +37,7 @@ type DatasetAPIClient interface {
 
 type FilterAPIClient interface {
 	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q *filter.QueryParams) (dims filter.Dimensions, eTag string, err error)
-	GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (m filter.Model, eTag string, err error)
+	GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (m filter.Model, err error)
 }
 
 // VaultClient contains the required methods for the Vault Client

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -14,11 +14,11 @@ var exportStart = `{
   "type": "record",
   "name": "cantabular-export-start",
   "fields": [
-    {"name": "instance_id", "type": "string", "default": ""},
-    {"name": "dataset_id",  "type": "string", "default": ""},
-    {"name": "edition",     "type": "string", "default": ""},
-    {"name": "version",     "type": "string", "default": ""},
-    {"name": "filter_id",   "type":"string",  "default": ""}
+    {"name": "instance_id", 		"type": "string", "default": ""},
+    {"name": "dataset_id",  		"type": "string", "default": ""},
+    {"name": "edition",     		"type": "string", "default": ""},
+    {"name": "version",     		"type": "string", "default": ""},
+    {"name": "filter_output_id",   "type":"string",  "default": ""}
   ]
 }`
 

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -60,7 +60,7 @@ type DatasetAPIClient interface {
 
 type FilterAPIClient interface {
 	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q *filter.QueryParams) (dims filter.Dimensions, eTag string, err error)
-	GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (m filter.Model, eTag string, err error)
+	GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (m filter.Model, err error)
 	Checker(context.Context, *healthcheck.CheckState) error
 }
 

--- a/service/mock/filter_api_client.go
+++ b/service/mock/filter_api_client.go
@@ -27,8 +27,8 @@ var _ service.FilterAPIClient = &FilterAPIClientMock{}
 // 			GetDimensionsFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, filterID string, q *filter.QueryParams) (filter.Dimensions, string, error) {
 // 				panic("mock out the GetDimensions method")
 // 			},
-// 			GetJobStateFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterID string) (filter.Model, string, error) {
-// 				panic("mock out the GetJobState method")
+// 			GetOutputFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterOutputID string) (filter.Model, error) {
+// 				panic("mock out the GetOutput method")
 // 			},
 // 		}
 //
@@ -43,8 +43,8 @@ type FilterAPIClientMock struct {
 	// GetDimensionsFunc mocks the GetDimensions method.
 	GetDimensionsFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, filterID string, q *filter.QueryParams) (filter.Dimensions, string, error)
 
-	// GetJobStateFunc mocks the GetJobState method.
-	GetJobStateFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterID string) (filter.Model, string, error)
+	// GetOutputFunc mocks the GetOutput method.
+	GetOutputFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterOutputID string) (filter.Model, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -70,8 +70,8 @@ type FilterAPIClientMock struct {
 			// Q is the q argument value.
 			Q *filter.QueryParams
 		}
-		// GetJobState holds details about calls to the GetJobState method.
-		GetJobState []struct {
+		// GetOutput holds details about calls to the GetOutput method.
+		GetOutput []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// UserAuthToken is the userAuthToken argument value.
@@ -82,13 +82,13 @@ type FilterAPIClientMock struct {
 			DownloadServiceToken string
 			// CollectionID is the collectionID argument value.
 			CollectionID string
-			// FilterID is the filterID argument value.
-			FilterID string
+			// FilterOutputID is the filterOutputID argument value.
+			FilterOutputID string
 		}
 	}
 	lockChecker       sync.RWMutex
 	lockGetDimensions sync.RWMutex
-	lockGetJobState   sync.RWMutex
+	lockGetOutput     sync.RWMutex
 }
 
 // Checker calls CheckerFunc.
@@ -177,10 +177,10 @@ func (mock *FilterAPIClientMock) GetDimensionsCalls() []struct {
 	return calls
 }
 
-// GetJobState calls GetJobStateFunc.
-func (mock *FilterAPIClientMock) GetJobState(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterID string) (filter.Model, string, error) {
-	if mock.GetJobStateFunc == nil {
-		panic("FilterAPIClientMock.GetJobStateFunc: method is nil but FilterAPIClient.GetJobState was just called")
+// GetOutput calls GetOutputFunc.
+func (mock *FilterAPIClientMock) GetOutput(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterOutputID string) (filter.Model, error) {
+	if mock.GetOutputFunc == nil {
+		panic("FilterAPIClientMock.GetOutputFunc: method is nil but FilterAPIClient.GetOutput was just called")
 	}
 	callInfo := struct {
 		Ctx                  context.Context
@@ -188,31 +188,31 @@ func (mock *FilterAPIClientMock) GetJobState(ctx context.Context, userAuthToken 
 		ServiceAuthToken     string
 		DownloadServiceToken string
 		CollectionID         string
-		FilterID             string
+		FilterOutputID       string
 	}{
 		Ctx:                  ctx,
 		UserAuthToken:        userAuthToken,
 		ServiceAuthToken:     serviceAuthToken,
 		DownloadServiceToken: downloadServiceToken,
 		CollectionID:         collectionID,
-		FilterID:             filterID,
+		FilterOutputID:       filterOutputID,
 	}
-	mock.lockGetJobState.Lock()
-	mock.calls.GetJobState = append(mock.calls.GetJobState, callInfo)
-	mock.lockGetJobState.Unlock()
-	return mock.GetJobStateFunc(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID)
+	mock.lockGetOutput.Lock()
+	mock.calls.GetOutput = append(mock.calls.GetOutput, callInfo)
+	mock.lockGetOutput.Unlock()
+	return mock.GetOutputFunc(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID)
 }
 
-// GetJobStateCalls gets all the calls that were made to GetJobState.
+// GetOutputCalls gets all the calls that were made to GetOutput.
 // Check the length with:
-//     len(mockedFilterAPIClient.GetJobStateCalls())
-func (mock *FilterAPIClientMock) GetJobStateCalls() []struct {
+//     len(mockedFilterAPIClient.GetOutputCalls())
+func (mock *FilterAPIClientMock) GetOutputCalls() []struct {
 	Ctx                  context.Context
 	UserAuthToken        string
 	ServiceAuthToken     string
 	DownloadServiceToken string
 	CollectionID         string
-	FilterID             string
+	FilterOutputID       string
 } {
 	var calls []struct {
 		Ctx                  context.Context
@@ -220,10 +220,10 @@ func (mock *FilterAPIClientMock) GetJobStateCalls() []struct {
 		ServiceAuthToken     string
 		DownloadServiceToken string
 		CollectionID         string
-		FilterID             string
+		FilterOutputID       string
 	}
-	mock.lockGetJobState.RLock()
-	calls = mock.calls.GetJobState
-	mock.lockGetJobState.RUnlock()
+	mock.lockGetOutput.RLock()
+	calls = mock.calls.GetOutput
+	mock.lockGetOutput.RUnlock()
 	return calls
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -101,8 +101,8 @@ func TestInit(t *testing.T) {
 				return filter.Dimensions{}, "", nil
 			},
 
-			GetJobStateFunc: func(ctx context.Context, uaToken string, saToken string, dsToken string, cID string, fID string) (filter.Model, string, error) {
-				return filter.Model{}, "", nil
+			GetOutputFunc: func(ctx context.Context, uaToken string, saToken string, dsToken string, cID string, fID string) (filter.Model, error) {
+				return filter.Model{}, nil
 			},
 		}
 		service.GetFilterAPIClient = func(cfg *config.Config) service.FilterAPIClient {


### PR DESCRIPTION
### What

The CSV's are not being generated on develop due to an error, which is linked the message that is put on the queue does not match the required schema.

* Replace 'filter_id' with 'filter_output_id' - The `ExportStart` event should contain the filter output ID instead of the filter id.
* Call GetOutput instead of GetJobState

Resolves: 5660

### How to review

Run tests and run it locally.

### Who can review

Team B developers
