### PR TITLE
5732 Do not add filter options if Options array is empty

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -141,10 +141,12 @@ func (h *InstanceComplete) getFilterInfo(ctx context.Context, filterOutputID str
 	filters := make([]cantabular.Filter, 0)
 	for _, d := range dimensions {
 		dimensionIds = append(dimensionIds, d.ID)
-		filters = append(filters, cantabular.Filter{
-			Codes:    d.Options,
-			Variable: d.Name,
-		})
+		if len(d.Options) > 0 {
+			filters = append(filters, cantabular.Filter{
+				Codes:    d.Options,
+				Variable: d.Name,
+			})
+		}
 	}
 
 	isPublished := model.IsPublished


### PR DESCRIPTION
### What

This resolves a GraphQL query error, as it expects `Codes` to be an
array with at least one option/string.

### How to review

Sense check it and ensure the tests are green

### Who can review

Any ONS developer
