### PR TITLE
5758 - Create Cantabular HTTPClient with DEFAULT_REQUEST_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An example event can be created using the helper script, `make produce`.
 | GRACEFUL_SHUTDOWN_TIMEOUT           | 5s                                   | The graceful shutdown timeout in seconds (`time.Duration` format)
 | HEALTHCHECK_INTERVAL                | 30s                                  | Time between self-healthchecks (`time.Duration` format)
 | HEALTHCHECK_CRITICAL_TIMEOUT        | 90s                                  | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
-| DEFAULT_REQUEST_TIMEOUT             | 10s                                  | Default timeout for graphQL queries against Cantabular API extension
+| DEFAULT_REQUEST_TIMEOUT             | 10s                                  | Default timeout for graphQL queries against Cantabular API extension and HTTP requests for the Cantabular Client only
 | SERVICE_AUTH_TOKEN                  |                                      | The service token for this app
 | CANTABULAR_URL                      | http://localhost:8491                | The Cantabular server URL
 | CANTABULAR_EXT_API_URL              | http://localhost:8492                | The Cantabular API extension URL

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -83,7 +83,7 @@ var GetCantabularClient = func(cfg *config.Config) CantabularClient {
 			ExtApiHost:     cfg.CantabularExtURL,
 			GraphQLTimeout: cfg.DefaultRequestTimeout,
 		},
-		dphttp.NewClient(),
+		dphttp.ClientWithTimeout(nil, cfg.DefaultRequestTimeout),
 		nil,
 	)
 }


### PR DESCRIPTION
### What

The current value of the httpClient is set to 10s.
Creating an HTTPClient with a default timeout will allow us to avoid a
GraphQL connection timeout when requesting data for very large datasets.

The reason this should prevent the timeout is because the GraphQL POST
query is done via the normal httpClient.

The error we are seeing in Kibana:

./dp-observation-api
```
  write tcp 172.17.0.17:50838->10.30.137.41:8182: write: broken pipe
```

dp-hierarchy-builder
```
  message": "write tcp 172.17.0.16:36782->10.30.136.54:8182: write: connection timed out
     event: "error from graph DB"
```

dp-cantabular-csv-export
```
   event: "failed to handle message"
  errors: "failed to upload .csv file to S3 bucket: failed to stream csv data:
           transform error: error decoding end of json object: error decoding json token:
           context deadline exceeded (Client.Timeout or context cancellation while reading body"
 ```

Resolves: [5758](https://trello.com/c/IG3gG3qN/5758-investigate-issue-with-large-file-generation-in-dp-cantabular-csv-exporter)

### How to review

Sense check it and ensure tests are :green_circle: 

### Who can review

Any ONS developer
