### PR TITLE
add coverage filters even if FilterBy is blank

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -142,12 +142,14 @@ func (h *InstanceComplete) getFilterInfo(ctx context.Context, filterOutputID str
 	for _, d := range dimensions {
 		dimensionIds = append(dimensionIds, d.ID)
 		if len(d.Options) > 0 {
+			v := d.ID
 			if len(d.FilterByParent) != 0 {
-				filters = append(filters, cantabular.Filter{
-					Codes:    d.Options,
-					Variable: d.FilterByParent,
-				})
+				v = d.FilterByParent
 			}
+			filters = append(filters, cantabular.Filter{
+				Codes:    d.Options,
+				Variable: v,
+			})
 		}
 	}
 


### PR DESCRIPTION
### What

Fix logic regarding FilterByParent and adding filters, currently a filter would only be added if FilterByParent has a value which is incorrect. The filter needs to be added if categories are present either way, only the variable changes depending on FilterByParent.

### How to review

Check change makes sense

### Who can review

Anyone