### PR TITLE
Mitigate S3 Bucket name clashes

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,2 @@
+#  CVE-2022-36129 pkg:golang/github.com/hashicorp/vault/api@v1.7.2 - 9.1/10 (Critical)
+CVE-2022-36129

--- a/features/dp-cantabular-csv-exporter-published-filtered.feature
+++ b/features/dp-cantabular-csv-exporter-published-filtered.feature
@@ -150,7 +150,7 @@ Feature: Cantabular-Csv-Exporter-Published-Filtered
         "CSV":{
           "href":"http://localhost:23600/downloads/filter-outputs/filter-output-happy-02.csv",
           "size": "626",
-          "public": "http://minio:9000/public-bucket/datasets/dataset-happy-02-edition-happy-02-version-happy-02-filtered-2022-01-26T12:27:04Z.csv",
+          "public": "http://minio:9000/public-bucket/datasets/dataset-happy-02-edition-happy-02-version-happy-02-filtered-2022-01-26T12:27:04Z-15f8e618-81f6-b1c9-eae9-e9496b05419.csv",
           "skipped": false
         }
       }
@@ -234,4 +234,4 @@ Feature: Cantabular-Csv-Exporter-Published-Filtered
 
     And one event with the following fields are in the produced kafka topic cantabular-csv-created:
       | InstanceID        | DatasetID        | Edition          | Version          | RowCount | FileName                                                                             | FilterOutputID         | Dimensions | 
-      | instance-happy-02 | dataset-happy-02 | edition-happy-02 | version-happy-02 | 22       | dataset-happy-02-edition-happy-02-version-happy-02-filtered-2022-01-26T12:27:04Z.csv | filter-output-happy-02 |[]          |
+      | instance-happy-02 | dataset-happy-02 | edition-happy-02 | version-happy-02 | 22       | dataset-happy-02-edition-happy-02-version-happy-02-filtered-2022-01-26T12:27:04Z-15f8e618-81f6-b1c9-eae9-e9496b05419.csv | filter-output-happy-02 |[]          |

--- a/features/steps/generator.go
+++ b/features/steps/generator.go
@@ -7,6 +7,7 @@ import (
 const (
 	testTimestamp = "2022-01-26T12:27:04.783936865Z"
 	testPSK       = "0123456789ABCDEF"
+	testUUID      = "15f8e618-81f6-b1c9-eae9-e9496b05419"
 )
 
 // Generator is responsible for randomly generating new strings and tokens
@@ -22,4 +23,8 @@ func (g *generator) NewPSK() ([]byte, error) {
 func (g *generator) Timestamp() time.Time {
 	t, _ := time.Parse(time.RFC3339, testTimestamp)
 	return t
+}
+
+func (g *generator) UniqueID() (string, error) {
+	return testUUID, nil
 }

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -3,6 +3,9 @@ package generator
 import (
 	"crypto/rand"
 	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/pkg/errors"
 )
 
 // Generator is responsible for randomly generating new strings and tokens
@@ -27,4 +30,12 @@ func (g *Generator) NewPSK() ([]byte, error) {
 // Timestamp generates a timestamp of the current time
 func (g *Generator) Timestamp() time.Time {
 	return time.Now()
+}
+
+func (g *Generator) UniqueID() (string, error) {
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate an UUID for the S3 filename")
+	}
+	return generateUUID, nil
 }

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 //go:generate moq -out mock/cantabular-client.go -pkg mock . CantabularClient
@@ -53,4 +54,5 @@ type VaultClient interface {
 type Generator interface {
 	NewPSK() ([]byte, error)
 	Timestamp() time.Time
+	UniqueID() (string, error)
 }

--- a/handler/mock/generator.go
+++ b/handler/mock/generator.go
@@ -25,6 +25,9 @@ var _ handler.Generator = &GeneratorMock{}
 // 			TimestampFunc: func() time.Time {
 // 				panic("mock out the Timestamp method")
 // 			},
+// 			UniqueIDFunc: func() (string, error) {
+// 				panic("mock out the UniqueID method")
+// 			},
 // 		}
 //
 // 		// use mockedGenerator in code that requires handler.Generator
@@ -38,6 +41,9 @@ type GeneratorMock struct {
 	// TimestampFunc mocks the Timestamp method.
 	TimestampFunc func() time.Time
 
+	// UniqueIDFunc mocks the UniqueID method.
+	UniqueIDFunc func() (string, error)
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// NewPSK holds details about calls to the NewPSK method.
@@ -46,9 +52,13 @@ type GeneratorMock struct {
 		// Timestamp holds details about calls to the Timestamp method.
 		Timestamp []struct {
 		}
+		// UniqueID holds details about calls to the UniqueID method.
+		UniqueID []struct {
+		}
 	}
 	lockNewPSK    sync.RWMutex
 	lockTimestamp sync.RWMutex
+	lockUniqueID  sync.RWMutex
 }
 
 // NewPSK calls NewPSKFunc.
@@ -100,5 +110,31 @@ func (mock *GeneratorMock) TimestampCalls() []struct {
 	mock.lockTimestamp.RLock()
 	calls = mock.calls.Timestamp
 	mock.lockTimestamp.RUnlock()
+	return calls
+}
+
+// UniqueID calls UniqueIDFunc.
+func (mock *GeneratorMock) UniqueID() (string, error) {
+	if mock.UniqueIDFunc == nil {
+		panic("GeneratorMock.UniqueIDFunc: method is nil but Generator.UniqueID was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockUniqueID.Lock()
+	mock.calls.UniqueID = append(mock.calls.UniqueID, callInfo)
+	mock.lockUniqueID.Unlock()
+	return mock.UniqueIDFunc()
+}
+
+// UniqueIDCalls gets all the calls that were made to UniqueID.
+// Check the length with:
+//     len(mockedGenerator.UniqueIDCalls())
+func (mock *GeneratorMock) UniqueIDCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockUniqueID.RLock()
+	calls = mock.calls.UniqueID
+	mock.lockUniqueID.RUnlock()
 	return calls
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -5,13 +5,14 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-cantabular-csv-exporter/config"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka/v3"
-	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -85,4 +86,5 @@ type VaultClient interface {
 type Generator interface {
 	NewPSK() ([]byte, error)
 	Timestamp() time.Time
+	UniqueID() (string, error)
 }


### PR DESCRIPTION
### What

As part of the Performance testing on our staging environment, the CSV and XLSX exporter S3 bucket operations have exposed a race condition when XLSX tries to copy the S3 file whilst the CSV is re-writing the file.

This is down to the S3 filename for a filtered output have a timestamp granularity of seconds, allowing for the possibility of S3 name clashes in the event where many requests are processed simultaneously.

As an example, "filtered" S3 filenames will change from
```
Testing-2021-data-v010-2021-1-filtered-2022-09-08T14:59:55+01:00.csv
```

to

```
Testing-2021-data-v010-2021-1-filtered-2022-09-08T14:59:55+01:00-2f09c03c-45f0-4ff9-9fa8-dabcf6034252.csv
```
### How to review

* Ensure tests are :green_circle: 
* Checkout the branch and bring your local docker setup up. 
* Check local minio to see that both the `csv` and `xlsx` files have been created with the `uuid`


### Who can review

Any ONS developer
