### PR TITLE
add nomad plan stanzas for parallel deployment

### DIFF
--- a/dp-cantabular-csv-exporter.nomad
+++ b/dp-cantabular-csv-exporter.nomad
@@ -7,7 +7,7 @@ job "dp-cantabular-csv-exporter" {
     stagger          = "60s"
     min_healthy_time = "30s"
     healthy_deadline = "2m"
-    max_parallel     = 1
+    max_parallel     = {{MAX_PARALLEL}}
     auto_revert      = true
   }
 
@@ -17,6 +17,10 @@ job "dp-cantabular-csv-exporter" {
     constraint {
       attribute = "${node.class}"
       value     = "publishing"
+    }
+
+    update {
+      max_parallel = {{PUBLISHING_MAX_PARALLEL}}
     }
 
     restart {
@@ -80,6 +84,10 @@ job "dp-cantabular-csv-exporter" {
     constraint {
       attribute = "${node.class}"
       value     = "web"
+    }
+
+    update {
+      max_parallel = {{WEB_MAX_PARALLEL}}
     }
 
     restart {


### PR DESCRIPTION
concourse is ready to populate these vars (defaults to `1` for all, but a manifest can override)
