### PR TITLE
Test dcind container

### DIFF
--- a/ci/component.yml
+++ b/ci/component.yml
@@ -1,11 +1,10 @@
 ---
-
 platform: linux
 
 image_resource:
   type: docker-image
   source:
-    repository: taylorsilva/dcind
+    repository: onsdigital/dcind
     tag: latest
 
 inputs:


### PR DESCRIPTION
### What

Ran into a problem with CI system failing running component test.
This PR is to test an ons version of the original dcind container.

### How to review

Does it work in CI for component test.

component test working on Ubuntu 20.04:
https://concourse.dp-ci.aws.onsdigital.uk/teams/main/pipelines/dp-cantabular-csv-exporter/jobs/pr-component/builds/197
component test working on Ubuntu 22.04:
https://concourse.dp-ci.aws.onsdigital.uk/teams/main/pipelines/dp-cantabular-csv-exporter/jobs/pr-component/builds/198

### Who can review

Anyone
