### PR TITLE
Release/1.18.0

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,2 +1,0 @@
-CVE-2024-2660 # no upgrade path as yet
-CVE-2025-4673 # Ignored due to golang.org/x/net v0.41.0 being the latest release

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.24.1-bullseye AS base
+FROM golang:1.24 AS base
 
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: audit test build
 
 .PHONY: audit
 audit:
-	go list -m all | nancy sleuth
+	dis-vulncheck
 
 .PHONY: build
 build:

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: onsdigital/dp-concourse-tools-nancy
+    repository: onsdigital/dp-concourse-tools-vulncheck
     tag: latest
 
 inputs:

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.7-bookworm
 
 inputs:
   - name: dp-cantabular-csv-exporter

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.7-bookworm
 
 inputs:
   - name: dp-cantabular-csv-exporter

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.7-bookworm
 
 inputs:
   - name: dp-cantabular-csv-exporter

--- a/features/compose/minio.yml
+++ b/features/compose/minio.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   minio:
-    image: 'bitnami/minio:latest'
+    image: 'bitnamilegacy/minio:latest'
     ports:
       - '9000:9000'
     healthcheck:


### PR DESCRIPTION
### What

- Switch to dis-vulncheck and bump Go version
- Dependency update

### How to review

- Check release is ok

### Who can review

Anyone
